### PR TITLE
Subscription URL should be escaped as a query

### DIFF
--- a/api/clash.go
+++ b/api/clash.go
@@ -208,7 +208,7 @@ func V2ray2Clash(c *gin.Context) {
 
 	requestURL := c.GetString("request_url")
 	if requestURL != "" {
-		clashx := fmt.Sprintf("clash://install-config?url=%s", url.PathEscape(requestURL))
+		clashx := fmt.Sprintf("clash://install-config?url=%s", url.QueryEscape(requestURL))
 		c.Redirect(http.StatusMovedPermanently, clashx)
 	} else {
 		c.String(http.StatusOK, util.UnicodeEmojiDecode(string(r)))


### PR DESCRIPTION
BUG FIX: if there are special characters like '...&parameter=...' in subscription URL in clash URL scheme, these parameters will be ignored by Clash for Windows.
Subscription URL should be considered as a Query, not a Path. & should be escaped too.
See: https://github.com/Fndroid/clash_for_windows_pkg/issues/795