### PR TITLE
Edited README, same bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Usage of ./clashconfig-linux-armv7:
         Listen Port (default "5050")
 ```
 2. 使用下面格式设置订阅链接，QuantumultX、Clash设置可以直接用浏览器访问构造好的链接，点击导入即可。
+
+* 注：QuantX和Clash系软件，若想在软件中直接获取配置文件，请将sub_link替换为lan_link。
 #### v2ray转clash
 ```
 http://127.0.0.1:5050/v2ray2clash?sub_link=此处换成需要转换的v2ray订阅链接

--- a/api/clash.go
+++ b/api/clash.go
@@ -197,7 +197,7 @@ func V2ray2Clash(c *gin.Context) {
 			clashVmess.WSPATH = vmess.Path
 		}
 
-		vmesss = append(vmesss, clashVmess)
+		vmesss = append(vmesss, clashVmess)//vmess config entries
 	}
 	clash := Clash{}
 	r := clash.LoadTemplate("ConnersHua.yaml", vmesss)

--- a/api/quantumultx.go
+++ b/api/quantumultx.go
@@ -140,7 +140,7 @@ func V2ray2Quanx(c *gin.Context) {
 			c.String(http.StatusBadRequest, "转换错误")
 			return
 		}
-		quantumultx := fmt.Sprintf("quantumult-x:///update-configuration?remote-resource=%s", url.PathEscape(string(b)))
+		quantumultx := fmt.Sprintf("quantumult-x:///update-configuration?remote-resource=%s", url.QueryEscape(string(b)))
 		c.Redirect(http.StatusMovedPermanently, quantumultx)
 	} else {
 		// c.String(http.StatusOK, configs)

--- a/middleware/pre.go
+++ b/middleware/pre.go
@@ -52,7 +52,7 @@ func PreMiddleware() gin.HandlerFunc {
 			return
 		}
 		sublink := rawURI[9:]
-		s, err := httpGet(sublink)
+		s, err := httpGet(sublink)//s - sub config raw content
 
 		if nil != err {
 			c.String(http.StatusBadRequest, "sublink 不能访问")
@@ -65,7 +65,7 @@ func PreMiddleware() gin.HandlerFunc {
 			protoPrefix = "ssr://"
 
 		}
-		decodeBody, err := util.Base64DecodeStripped(string(s))
+		decodeBody, err := util.Base64DecodeStripped(string(s))//decodeBody: decoded config
 		if nil != err || !strings.HasPrefix(string(decodeBody), protoPrefix) {
 			log.Println(err)
 			c.String(http.StatusBadRequest, "sublink 返回数据格式不对")
@@ -80,7 +80,7 @@ func PreMiddleware() gin.HandlerFunc {
 
 		if strings.HasPrefix(rawURI, "sub_link") {
 			requestURL := fmt.Sprintf("%s://%s%s?lan_link=%s", scheme, c.Request.Host, c.Request.URL.Path, sublink)
-			c.Set("request_url", requestURL)
+			c.Set("request_url", requestURL)//lan link
 		}
 
 		c.Set("decodebody", string(decodeBody))


### PR DESCRIPTION
switch QuantmultX URL Scheme to use QueryEscape function.
noticed user to use lan_link to replace sub_link to get configs in QX and Clash directly